### PR TITLE
add lock/synchronize mechanism to fix bad authorization issue

### DIFF
--- a/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
@@ -233,12 +233,12 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
             scanner.close();
 
         }
-        catch (AccumuloSecurityException securityException) {
-            if( securityException.getMessage() != null) {
-                if(securityException.getMessage().contains("BAD_AUTHORIZATIONS")) {
-                    System.out.println("AccumuloOperationsApiImpl:enumerateRows: Ignoring BAD_AUTHORIZATIONS intentionally= " + securityException.getMessage());
-                }
+        catch (Exception e) {
+            log.error("Exception catched and thrown again in enumerateRows: " + e.toString());
+            if (e.getMessage() != null && (e.getMessage().contains("BAD_AUTHORIZATIONS"))) {
+                log.error("AccumuloOperationsApiImpl:enumerateRows:Got Exception BAD_AUTHORIZATIONS =" + e.getMessage());
             }
+            throw e;
         }
         return output;
     }
@@ -255,7 +255,7 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
      * @throws TableNotFoundException table not found
      * @throws AccumuloException in case of accumulo error
      */
-    public Map<String[], Value> readOneRow(Connector conn, String tableName, Text rowID, Text colFam, Text colQual, String visibility) throws TableNotFoundException, AccumuloException {
+    public Map<String[], Value> readOneRow(Connector conn, String tableName, Text rowID, Text colFam, Text colQual, String visibility) throws TableNotFoundException, AccumuloException, AccumuloSecurityException {
         Map<String[], Value> output = new HashMap<>();
         try {
 
@@ -279,13 +279,14 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
             }
             scanner.close();
         }
-        catch (AccumuloSecurityException securityException) {
-            log.error("AccumuloSecurityException catched in readOneRow: " + securityException.toString());
-            if( securityException.getMessage() != null) {
-                if(securityException.getMessage().contains("BAD_AUTHORIZATIONS")) {
-                    log.error("AccumuloOperationsApiImpl:readOneRow:Ignoring BAD_AUTHORIZATIONS intentionally= " + securityException.getMessage());
-                }
+        catch (Exception e) {
+            log.error("Exception catched and thrown again in readOneRow: " + e.toString());
+            if (e.getMessage() != null && (e.getMessage().contains("BAD_AUTHORIZATIONS"))) {
+                log.error("AccumuloOperationsApiImpl:readOneRow:Got Exception BAD_AUTHORIZATIONS =" + e.getMessage());
+                log.error("authorizaions request: " + visibility);
+                log.error("authorizaions actual: " + conn.securityOperations().getUserAuthorizations("root").toString());
             }
+            throw e;
         }
         return output;
     }
@@ -325,12 +326,12 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
             }
             scanner.close();
         }
-        catch (AccumuloSecurityException securityException) {
-            if( securityException.getMessage() != null) {
-                if(securityException.getMessage().contains("BAD_AUTHORIZATIONS")) {
-                    System.out.println("AccumuloOperationsApiImpl:readOneRowAccuFormat:Ignoring BAD_AUTHORIZATIONS intentionally= " + securityException.getMessage());
-                }
+        catch (Exception e) {
+            log.error("Exception catched and thrown again in readOneRowAccuFormat: " + e.toString());
+            if (e.getMessage() != null && (e.getMessage().contains("BAD_AUTHORIZATIONS"))) {
+                log.error("AccumuloOperationsApiImpl:readOneRowAccuFormat:Got Exception BAD_AUTHORIZATIONS =" + e.getMessage());
             }
+            throw e;
         }
         return output;
     }

--- a/comet-accumulo/src/main/java/org/renci/comet/api/DeleteScopeApiController.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/api/DeleteScopeApiController.java
@@ -89,27 +89,27 @@ public class DeleteScopeApiController implements DeleteScopeApi {
 		}
 
 		if (certValid && accept != null && accept.contains("application/json")) {
-        		try {
-        			log.debug("DeleteScope: certificate is valid.");
-        			CometOps cometOps = new CometOps();
-        			log.debug("DeleteScope Operation: contectID: " + contextID + "; family: " + family + "; key: " + key + "; readToken: " + readToken + "; writeToken: " + writeToken);
-        			JSONObject output = cometOps.deleteScope(contextID, family, key, readToken, writeToken);
-        			//return new ResponseEntity<CometResponse>(objectMapper.readValue("{  \"message\" : \"message\",  \"value\" : \"{}\",  \"version\" : \"version\",  \"status\" : \"status\"}", CometResponse.class), HttpStatus.OK);
-                CometResponse comet = new CometResponse();
-                comet.setValue(output.toString());
-                comet.setStatus("OK");
-                comet.setMessage("message");
-                comet.setVersion("0.1");
-                //System.out.println(comet.toString());
-                String crTemp = "{  \"message\" : \"success\",  \"value\" : " + output.toString() + ",  \"version\" : \"" + CometInitializer.COMET_VERSION + "\",  \"status\" : \"OK\"}";
-                return new ResponseEntity<CometResponse>(objectMapper.readValue(crTemp, CometResponse.class), HttpStatus.OK);
-        		} catch (IOException ioe) {
-                log.error("Couldn't serialize response for content type application/json", ioe);
+			try {
+				log.debug("DeleteScope: certificate is valid.");
+				CometOps cometOps = CometOps.getInstance();
+				log.debug("DeleteScope Operation: contectID: " + contextID + "; family: " + family + "; key: " + key + "; readToken: " + readToken + "; writeToken: " + writeToken);
+				JSONObject output = cometOps.deleteScope(contextID, family, key, readToken, writeToken);
+				//return new ResponseEntity<CometResponse>(objectMapper.readValue("{  \"message\" : \"message\",  \"value\" : \"{}\",  \"version\" : \"version\",  \"status\" : \"status\"}", CometResponse.class), HttpStatus.OK);
+				CometResponse comet = new CometResponse();
+				comet.setValue(output.toString());
+				comet.setStatus("OK");
+				comet.setMessage("message");
+				comet.setVersion("0.1");
+				//System.out.println(comet.toString());
+				String crTemp = "{  \"message\" : \"success\",  \"value\" : " + output.toString() + ",  \"version\" : \"" + CometInitializer.COMET_VERSION + "\",  \"status\" : \"OK\"}";
+				return new ResponseEntity<CometResponse>(objectMapper.readValue(crTemp, CometResponse.class), HttpStatus.OK);
+			} catch (IOException ioe) {
+				log.error("Couldn't serialize response for content type application/json", ioe);
+				return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+			} catch (Exception e) {
+				log.error("Accumulo internal error", e);
                 return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
-             } catch (Exception e) {
-        			log.error("Accumulo internal error", e);
-                return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
-        		}
+			}
         }
 
         ResponseEntity<CometResponse> cr = new ResponseEntity<CometResponse>(HttpStatus.BAD_REQUEST);

--- a/comet-accumulo/src/main/java/org/renci/comet/api/EnumerateScopeApiController.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/api/EnumerateScopeApiController.java
@@ -72,7 +72,7 @@ public class EnumerateScopeApiController implements EnumerateScopeApi {
             //if (certValid) {
             // For testing only
             try {
-                CometOps cometOps = new CometOps();
+                CometOps cometOps = CometOps.getInstance();
                 JSONObject output = new JSONObject();
                 if (family != null) {
                 		output = cometOps.enumerateScopesWithFamily(contextID, family, readToken);
@@ -91,9 +91,9 @@ public class EnumerateScopeApiController implements EnumerateScopeApi {
             } catch (IOException ioe) {
                 log.error("Couldn't serialize response for content type application/json", ioe);
                 return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
-         } catch (Exception e) {
+            } catch (Exception e) {
                 log.error("Accumulo internal error", e);
-            return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+                return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
             }
         }
 

--- a/comet-accumulo/src/main/java/org/renci/comet/api/ReadScopeApiController.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/api/ReadScopeApiController.java
@@ -105,29 +105,29 @@ public class ReadScopeApiController implements ReadScopeApi {
         log.debug("ReadScope operation: contextID: " + contextID + "\n family: " + family + "\n key: " + key + "\n readToken: " + readToken);
 
 		if (accept != null && accept.contains("application/json")) {
-        		try {
-        			CometOps cometOps = new CometOps();
-        			//JSONObject test = cometOps.readScope("id0001", "hero", "name", "secretId");
-        			//System.out.println(test);
-        			JSONObject output = cometOps.readScope(contextID, family, key, readToken);
-        			ObjectMapper objectMapper = new ObjectMapper();
-        			CometResponse comet = new CometResponse();
-        			comet.setValue(output.toString());
-        			comet.setStatus("OK");
-        			comet.setMessage("message");
-        			comet.setVersion("0.1");
-        			//System.out.println(comet.toString());
-        			String crTemp = "{  \"message\" : \"success\",  \"value\" : " + output.toString() + ",  \"version\" : \"" + CometInitializer.COMET_VERSION + "\",  \"status\" : \"OK\"}";
-        			//System.out.println(crTemp);
-        			//return new ResponseEntity<CometResponse>(objectMapper.readValue("{  \"message\" : \"message\",  \"value\" : \"{}\",  \"version\" : \"version\",  \"status\" : \"status\"}", CometResponse.class), HttpStatus.OK);
-        			return new ResponseEntity<CometResponse>(objectMapper.readValue(crTemp, CometResponse.class), HttpStatus.OK);
-        		} catch (IOException ioe) {
-                    log.error("Couldn't serialize response for content type application/json", ioe);
-                    return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
-             } catch (Exception e) {
-        			log.error("Accumulo internal error", e);
+			try {
+				CometOps cometOps = CometOps.getInstance();
+				//JSONObject test = cometOps.readScope("id0001", "hero", "name", "secretId");
+				//System.out.println(test);
+				JSONObject output = cometOps.readScope(contextID, family, key, readToken);
+				ObjectMapper objectMapper = new ObjectMapper();
+				CometResponse comet = new CometResponse();
+				comet.setValue(output.toString());
+				comet.setStatus("OK");
+				comet.setMessage("message");
+				comet.setVersion("0.1");
+				//System.out.println(comet.toString());
+				String crTemp = "{  \"message\" : \"success\",  \"value\" : " + output.toString() + ",  \"version\" : \"" + CometInitializer.COMET_VERSION + "\",  \"status\" : \"OK\"}";
+				//System.out.println(crTemp);
+				//return new ResponseEntity<CometResponse>(objectMapper.readValue("{  \"message\" : \"message\",  \"value\" : \"{}\",  \"version\" : \"version\",  \"status\" : \"status\"}", CometResponse.class), HttpStatus.OK);
+				return new ResponseEntity<CometResponse>(objectMapper.readValue(crTemp, CometResponse.class), HttpStatus.OK);
+			} catch (IOException ioe) {
+				log.error("Couldn't serialize response for content type application/json", ioe);
+				return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+			} catch (Exception e) {
+				log.error("Accumulo internal error", e);
                 return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
-        		}
+			}
         }
 
         ResponseEntity<CometResponse> cr = new ResponseEntity<CometResponse>(HttpStatus.BAD_REQUEST);

--- a/comet-accumulo/src/main/java/org/renci/comet/api/WriteScopeApiController.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/api/WriteScopeApiController.java
@@ -79,7 +79,7 @@ public class WriteScopeApiController implements WriteScopeApi {
         }
         
         JSONObject output = new JSONObject();
-        CometOps cometOps = new CometOps();
+        CometOps cometOps = CometOps.getInstance();
         
         // Check if scope exists, if no such scope, create a new scope which does not require valid certificate.
         try {
@@ -94,11 +94,17 @@ public class WriteScopeApiController implements WriteScopeApi {
             log.error("Accumulo internal error", e1);
             return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        catch (AccumuloSecurityException e1) {
-                // Intentionally ignoring the exception
-                e1.printStackTrace();
+        catch (Exception e) {
+            if (e.getMessage() != null && (e.getMessage().contains("BAD_AUTHORIZATIONS"))) {
+                log.error("CometOps:writeScope: Intentionally ignoring the Exception; assuming row does not exist");
+                e.printStackTrace();
+            }
+            else {
+                log.error("Accumulo internal error", e);
+                return new ResponseEntity<CometResponse>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
-        
+
         if (certs != null) {
             try {
                 for (int i = 0; i < certs.length; i++)


### PR DESCRIPTION
Resolving #20. 
The reason is because the root authorizations was overwritten by other threads (and the other headnode as well.) Adding lock and synchronized mechanism to protect multi-thread accessing and using one headnode for now. 