### PR TITLE
Setting docker logging driver to none

### DIFF
--- a/vmware-cluster/docker-compose.yml
+++ b/vmware-cluster/docker-compose.yml
@@ -28,3 +28,5 @@ services:
       COMET_SSL_KEY_PWD: 'changeme'
       COMET_SSL_TRUST_STORE: comettrustedstore.jks
       COMET_SSL_TRUST_STORE_PWD: 'changeme'
+    logging:
+      driver: "none"


### PR DESCRIPTION
To avoid comet logs go to /var/log/messages which leads comet headnode disk to grow very fast