### PR TITLE
To enable multiple comet headnodes

### DIFF
--- a/comet-accumulo/src/main/java/org/renci/comet/CometOps.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/CometOps.java
@@ -145,7 +145,6 @@ public class CometOps implements CometOpsIfce {
                         + ", userName: " +  userName
                         + ", password: " +  password
                         + ", tableName: " +  tableName); */
-
                 return new String[] {checkTokenStrength, checkClientCert, instanceName, zooServers, userName, password, tableName};
     
             } catch (IOException ex) {
@@ -212,7 +211,7 @@ public class CometOps implements CometOpsIfce {
         synchronized (this) {
             Instance inst = new ZooKeeperInstance(instanceName, zooServers);
             Connector conn = inst.getConnector(userName, new PasswordToken(password));
-            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl();
+            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl(userName);
             JSONObject jsonOutput = null;
 
             Text rowID = new Text(contextID);
@@ -300,7 +299,7 @@ public class CometOps implements CometOpsIfce {
         synchronized (this) {
             Instance inst = new ZooKeeperInstance(instanceName, zooServers);
             Connector conn = inst.getConnector(userName, new PasswordToken(password));
-            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl();
+            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl(userName);
             JSONObject jsonOutput = new JSONObject();
 
             Text rowID = new Text(contextID);
@@ -382,7 +381,7 @@ public class CometOps implements CometOpsIfce {
         synchronized (this) {
             Instance inst = new ZooKeeperInstance(instanceName, zooServers);
             Connector conn = inst.getConnector(userName, new PasswordToken(password));
-            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl();
+            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl(userName);
 
             Text rowID = new Text(contextID);
             Text colFam = new Text(family);
@@ -455,7 +454,7 @@ public class CometOps implements CometOpsIfce {
         synchronized (this) {
             Instance inst = new ZooKeeperInstance(instanceName, zooServers);
             Connector conn = inst.getConnector(userName, new PasswordToken(password));
-            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl();
+            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl(userName);
 
             Text rowID = new Text(contextID);
             Map<String[], Value> output = new HashMap<String[], Value>();
@@ -542,7 +541,7 @@ public class CometOps implements CometOpsIfce {
         synchronized (this) {
             Instance inst = new ZooKeeperInstance(instanceName, zooServers);
             Connector conn = inst.getConnector(userName, new PasswordToken(password));
-            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl();
+            AccumuloOperationsApiImpl accu = new AccumuloOperationsApiImpl(userName);
 
             Text rowID = new Text(contextID);
             Map<String[], Value> output = new HashMap<String[], Value>();

--- a/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
@@ -41,9 +41,19 @@ import java.util.concurrent.TimeUnit;
 
 
 public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
-    public static String ERROR = "error";
-    public static String SUCCESS = "Success";
+    public static final String ERROR = "error";
+    public static final String SUCCESS = "Success";
     private static final Logger log = Logger.getLogger(AccumuloOperationsApiImpl.class);
+    private static String user;
+    
+    /**
+     * Constructor
+     * @param username username to access accumulo
+     */
+    public AccumuloOperationsApiImpl(String username) {
+        super();
+        user = username;
+    }
 
     /**
      * Create unified JSONObject
@@ -214,7 +224,7 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
             //ScannerOpts scanOpts = new ScannerOpts();
             // Create a scanner
             Authorizations auths = new Authorizations(visibility);
-            conn.securityOperations().changeUserAuthorizations("root", auths);
+            conn.securityOperations().changeUserAuthorizations(user, auths);
             Scanner scanner = conn.createScanner(tableName, auths);
             //scanner.setBatchSize(scanOpts.scanBatchSize);
             // Say start key is the one with key of row
@@ -266,7 +276,7 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
             //ScannerOpts scanOpts = new ScannerOpts();
             // Create a scanner
             Authorizations auths = new Authorizations(visibility);
-            conn.securityOperations().changeUserAuthorizations("root", auths);
+            conn.securityOperations().changeUserAuthorizations(user, auths);
             Scanner scanner = conn.createScanner(tableName, auths);
             //scanner.setBatchSize(scanOpts.scanBatchSize);
             // Say start key is the one with key of row
@@ -292,7 +302,7 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
             if (e.getMessage() != null && (e.getMessage().contains("BAD_AUTHORIZATIONS"))) {
                 log.error("AccumuloOperationsApiImpl:readOneRow:Got Exception BAD_AUTHORIZATIONS =" + e.getMessage());
                 log.error("authorizaions request: " + visibility);
-                log.error("authorizaions actual: " + conn.securityOperations().getUserAuthorizations("root").toString());
+                log.error("authorizaions actual: " + conn.securityOperations().getUserAuthorizations(user).toString());
             }
             throw e;
         }
@@ -319,7 +329,7 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
             //ScannerOpts scanOpts = new ScannerOpts();
             // Create a scanner
             Authorizations auths = new Authorizations(visibility);
-            conn.securityOperations().changeUserAuthorizations("root", auths);
+            conn.securityOperations().changeUserAuthorizations(user, auths);
             Scanner scanner = conn.createScanner(tableName, auths);
             //scanner.setBatchSize(scanOpts.scanBatchSize);
             // Say start key is the one with key of row

--- a/comet-accumulo/src/main/resources/logback.xml
+++ b/comet-accumulo/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>/var/log/comet_%i.log</fileNamePattern>
-            <maxIndex>10</maxIndex>
+            <maxIndex>8</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
             <maxFileSize>500MB</maxFileSize>
@@ -34,7 +34,7 @@
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>/var/log/comet_err_%i.log</fileNamePattern>
-            <maxIndex>10</maxIndex>
+            <maxIndex>3</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
             <maxFileSize>500MB</maxFileSize>

--- a/vmware-cluster/Readme.md
+++ b/vmware-cluster/Readme.md
@@ -137,16 +137,51 @@ Execute the following commands in order as root user
 ```
 ./setup.sh resourcemgr
 ```
-#### accumulomaster
+#### Accumulomaster
 ```
 ./setup.sh master
 ```
-#### workers
+
+**[First-Time Setup for new comet head node]**
+
+* If the table which the new comet head node(s) going to use is not yet existing,
+create a new table by:
+
+
+```
+#./create-accu-table.sh
+password of accumulo root:
+new table name: < tablename >
+
+```
+
+
+* Each comet head node will use its own username/password to communicate with Accumulo.
+To create new user in Accumulo for the new comet head node:
+
+```
+#./create-accu-user.sh
+password of accumulo root:
+username of the new user: < username >
+Enter new password for 'username': < password >
+Please confirm new password for 'username': < password >
+Enter the table name for the user to READ/WRITE: < tablename >
+
+```
+
+
+#### Workers
 ```
 ./setup.sh worker
 ```
-#### headnodes
+#### Head nodes
 NOTE: All commands to be executed as root user
+
+**[Before starting new head node]**
+Each head node uses its own username/password to communicate with Accumulo. Make sure the username/password are created in Accumulo for every headnode. see [First-Time Setup in Accumulo](#Accumulomaster).
+
+**[Start comet head nodes]**
+
 - Clone code and go to vmware-cluster
 ```
 git clone https://github.com/RENCI-NRIG/COMET-Accumulo.git
@@ -165,6 +200,7 @@ cd COMET-Accumulo/vmware-cluster/
     environment:
       ACCUMULO_USER: < username >
       ACCUMULO_PASSWORD: < password >
+      ACCUMULO_TABLENAME: < tablename >
 ```
 - Bring up comet head node
 ```

--- a/vmware-cluster/Readme.md
+++ b/vmware-cluster/Readme.md
@@ -153,6 +153,7 @@ git clone https://github.com/RENCI-NRIG/COMET-Accumulo.git
 cd COMET-Accumulo/vmware-cluster/
 ```
 - Update docker-compose.yml to include IPs for zoo servers and workers
+  and set the accumulo username/password of this comet head node
 
 ```
     extra_hosts:
@@ -161,6 +162,9 @@ cd COMET-Accumulo/vmware-cluster/
       - "zoo3:192.168.100.31"
       - "comet-w1:192.168.100.32"
       - "comet-w2:192.168.100.33"
+    environment:
+      ACCUMULO_USER: < username >
+      ACCUMULO_PASSWORD: < password >
 ```
 - Bring up comet head node
 ```

--- a/vmware-cluster/create-accu-table.sh
+++ b/vmware-cluster/create-accu-table.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+read -sp 'password of accumulo root: ' rootpass; echo
+read -p 'new table name: ' table
+
+runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"createtable $table\""

--- a/vmware-cluster/create-accu-user.sh
+++ b/vmware-cluster/create-accu-user.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+read -sp 'password of accumulo root: ' rootpass; echo
+read -p 'username of the new user: ' username
+
+runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"createuser $username\""
+
+read -p 'Enter the table name for the user to READ/WRITE: ' table
+runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"grant Table.READ -t ${table} -u ${username}\""
+runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"grant Table.WRITE -t ${table} -u ${username}\""
+runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"grant -s System.ALTER_USER -u ${username}\""


### PR DESCRIPTION
To enable multiple comet head nodes we can let different comet head nodes to use different user accounts to access Accumulo. In that case, the authentication of user won't be modified/overwritten by each other.

We will stop using "root" user from comet head nodes. Instead, for each comet head node, we will create a specific Accumulo user for it, which also improves the security.

close #30 