### PR TITLE
let data to be deleted by user or accumulo ageoff filter

### DIFF
--- a/Dockerizing.md
+++ b/Dockerizing.md
@@ -106,7 +106,7 @@ For some accumulo operations such as read and enumerate, COMET will retry for th
 ### `COMET_RECORD_EXPIRE_TIME`
 
 In milliseconds. <br>
-Records are expected to access (i.e. Read or Write) at least once in this period of time in order to keep records alive.
+Records are expected to access (i.e. Read/Enumerate/Write) at least once in this period of time in order to keep records alive.
 Otherwise records might be deleted by Accumulo ageoff feature. <br>
 <br>
 Default value is 0, which means Comet won't do anything to guarantee TTL. <br> 

--- a/Dockerizing.md
+++ b/Dockerizing.md
@@ -1,4 +1,5 @@
-This is the docker image of [COMET server](https://github.com/RENCI-NRIG/COMET-Accumulo/tree/dockerize/).
+
+# [COMET Docker image](https://hub.docker.com/repository/docker/rencinrig/comet-spring)
 
 ## Pull image from dockerhub
 
@@ -27,7 +28,7 @@ Run together with zookeeper and RENCI accumulo docker images to form the cluster
 - [Zookeeper](https://hub.docker.com/_/zookeeper)
 - [Accumulo](https://github.com/RENCI-NRIG/accumulo)
 
-The [docker-compose.yml](https://github.com/RENCI-NRIG/COMET-Accumulo/tree/dockerize/docker-compose/docker-compose.yml) and the site-files to start the Accumulo cluster instances are under folder [docker-compose](docker-compose).
+The [docker-compose.yml](docker-compose/docker-compose.yml) and the site-files to start the Accumulo cluster instances are under folder [docker-compose](docker-compose).
 
 Start Comet after Zookeepers and Accumulo are ready:
 ```
@@ -98,20 +99,28 @@ Accumulo table name. Default is `trace`.
 
 ### `COMET_RETRY_DURATION`
 
-For some accumulo operations such as read and enumerate, COMET will retry for this duration of time. Default is `1000` milliseconds.
+In milliseconds. <br>
+Default is `1000` (1s). <br>
+For some accumulo operations such as read and enumerate, COMET will retry for this duration of time. 
+
+### `COMET_RECORD_EXPIRE_TIME`
+
+In milliseconds. <br>
+Records are expected to access (i.e. Read or Write) at least once in this period of time in order to keep records alive.
+Otherwise records might be deleted by Accumulo ageoff feature. <br>
+<br>
+Default value is 0, which means Comet won't do anything to guarantee TTL. <br> 
+**If Accumulo has AgeOffFilter set up already, records might be lost.**
 
 
-You can use a file of environment variables: 
-
-Example of `comet_example.env`:
-
+## Example
 ```
 COMET_CHECK_TOKEN_STRENGTH=false
 COMET_CHECK_CLIENT_CERT=false
 ACCUMULO_INSTANCE=docker-development
 ACCUMULO_ZOOSERVERS=zoo1,zoo2,zoo3
-ACCUMULO_USER=root
-ACCUMULO_PASSWORD=secret
+ACCUMULO_USER=user
+ACCUMULO_PASSWORD=password
 ACCUMULO_TABLENAME=trace
 ```
 

--- a/aws-accumulo/README.md
+++ b/aws-accumulo/README.md
@@ -13,63 +13,63 @@ See official documentation for more information.
 ### Pre-requisites
 1. User must have AWS account with privilges to create/delete IAMRole, IAMPolicy and IAMProfile
 2. Key pair has been created
-3. Update ACCUMULO_PASSWORD in [setupaccumulo.sh](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/config/setupaccumulo.sh). Default value for ACCUMULO_PASSWORD is secret.
+3. Update ACCUMULO_PASSWORD in [setupaccumulo.sh](config/setupaccumulo.sh). Default value for ACCUMULO_PASSWORD is secret.
 ### Accumulo Cluster created 
-![Cluster](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/cluster.png)
+![Cluster](images/cluster.png)
 ### Create a Accumulo Stack
 Create a stack on AWS Cloudformation service by using accumuloCloudFormation.json. 
 #### Logon to AWS Console and Search for Cloudformation service
-![Cloudformation](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/aws1.png)
+![Cloudformation](images/aws1.png)
 #### Click Create 
-![Cloudformation](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/aws2.png)
+![Cloudformation](images/aws2.png)
 #### Choose accumuloCloudFormation.json and click Next
-![Cloudformation](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/aws3.png)
+![Cloudformation](images/aws3.png)
 #### Specify the Stack name and KeyPair and click Next
-![Cloudformation](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/aws4.png)
+![Cloudformation](images/aws4.png)
 #### Click Next
-![Cloudformation](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/aws5.png)
+![Cloudformation](images/aws5.png)
 #### Ensure the checkbox for IAMRole warning is checked and click Create
-![Cloudformation](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/aws6.png)
+![Cloudformation](images/aws6.png)
 #### Stack creation will begin and status will be displayed as below
-![Cloudformation](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/aws7.png)
+![Cloudformation](images/aws7.png)
 
 ### namenode instance: NameNode Web UI on port 50070
 
 NameNode: http://[PublicIPv4 of Instance]:50070/dfshealth.html#tab-datanode
 
-![NameNode](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/namenode.png)
+![NameNode](images/namenode.png)
 
 ### resourcemanager instance: ResourceManager Web UI on port 8088
 
 ResourceManager: http://[PublicIPv4 of Instance]:8088
 
-![ResourceManager](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/resourcemanager.png)
+![ResourceManager](images/resourcemanager.png)
 
 ### accumulomaster instance: Accumulomaster Web UI on port 9995
 
 Accumulomaster: http://[PublicIPv4 of Instance]:9995
 
-![Accumulomaster](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/accumulomaster.png)
+![Accumulomaster](images/accumulomaster.png)
 
 ### worker instance: Worker Web UI on port 9995
 
 Worker: http://[PublicIPv4 of Instance]:9995
 
-![Worker](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/images/worker1.png)
+![Worker](images/worker1.png)
 
 ## Test Cluster
 NOTE: Assumes the cluster is running as configured.
 
-A script named [usertable-example.sh](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/test/usertable-example.sh) will create a sample usertable in Accumulo using 100 randomly generated user entries. 
+A script named [usertable-example.sh](test/usertable-example.sh) will create a sample usertable in Accumulo using 100 randomly generated user entries. 
 
 This script should be executed on accumulomaster console as root user.
 
 ## Accumulo stack hacks
 ### Launch Accumulo with one worker
-1. Edit [accumuloCloudFormation.json](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/accumuloCloudFormation.json) and remove the section for worker2 line 600-705
-2. Replace worker2 with empty string in [accumuloCloudFormation.json](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/accumuloCloudFormation.json)
+1. Edit [accumuloCloudFormation.json](accumuloCloudFormation.json) and remove the section for worker2 line 600-705
+2. Replace worker2 with empty string in [accumuloCloudFormation.json](accumuloCloudFormation.json)
 ### Launch Multiple Accumulo stacks
-1. Make copy of [accumuloCloudFormation.json](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/accumuloCloudFormation.json)
-2. Replace bucket name i.e. cometbucket in [accumuloCloudFormation.json](https://github.com/RENCI-NRIG/COMET-Accumulo/blob/brAwsAccumulo/aws-accumulo/accumuloCloudFormation.json) to a different name in one of the files
+1. Make copy of [accumuloCloudFormation.json](accumuloCloudFormation.json)
+2. Replace bucket name i.e. cometbucket in [accumuloCloudFormation.json](accumuloCloudFormation.json) to a different name in one of the files
 
 

--- a/aws-accumulo/docker/comet/docker-compose.yml
+++ b/aws-accumulo/docker/comet/docker-compose.yml
@@ -31,5 +31,6 @@ services:
       COMET_SSL_TRUST_STORE: comettrustedstore.jks
       COMET_SSL_TRUST_STORE_PWD: 'changeme'
       COMET_RETRY_DURATION: '1000'
+      #COMET_RECORD_EXPIRE_TIME: '0' #please see Dockerizing.md to set this value
     logging:
       driver: "none"

--- a/comet-accumulo/pom.xml
+++ b/comet-accumulo/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>comet-spring</artifactId>
     <packaging>jar</packaging>
     <name>comet-spring</name>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
     <properties>
         <java.version>1.7</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/comet-accumulo/src/main/java/org/renci/comet/CometInitializer.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/CometInitializer.java
@@ -12,7 +12,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 @ComponentScan(basePackages = { "org.renci.comet", "org.renci.comet.api" })
 public class CometInitializer implements CommandLineRunner {
-	public static final String COMET_VERSION = "1.0.0";
+	public static final String COMET_VERSION = "1.0.5";
 	public static final String COMET_API_VERSION = "1.0.0";
 	public static final String COMET_SCHEMA_VERSION = "1.0.0";
     @Override

--- a/comet-accumulo/src/main/java/org/renci/comet/CometInitializer.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/CometInitializer.java
@@ -14,7 +14,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class CometInitializer implements CommandLineRunner {
 	public static final String COMET_VERSION = "1.0.5";
 	public static final String COMET_API_VERSION = "1.0.0";
-	public static final String COMET_SCHEMA_VERSION = "1.0.0";
+	public static final String COMET_SCHEMA_VERSION = "1.0.1";
     @Override
     public void run(String... arg0) throws Exception {
         if (arg0.length > 0 && arg0[0].equals("exitcode")) {

--- a/comet-accumulo/src/main/java/org/renci/comet/CometOps.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/CometOps.java
@@ -103,7 +103,6 @@ public class CometOps implements CometOpsIfce {
             catch(Exception e) {
                 log.error(e);
                 log.error("ageoff config failed - check with accumulo admin to see if you have permission" );
-                System.exit(1);
             }
         }
     }

--- a/comet-accumulo/src/main/java/org/renci/comet/CometOps.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/CometOps.java
@@ -68,7 +68,7 @@ public class CometOps implements CometOpsIfce {
     public static final int FIELD_DELTIMESTAMP = 4;
     public static final int FIELD_WRITETIMESTAMP = 5;
 
-    /* following are what inside in entry read/enumerated from AccumuloOperationsApiImpl */
+    /* following are the fields in key (string[]) of entry read/enumerated from AccumuloOperationsApiImpl */
     public static final int INDEX_ROW = AccumuloOperationsApiImpl.INDEX_ROW;
     public static final int INDEX_FAMILY = AccumuloOperationsApiImpl.INDEX_FAMILY;
     public static final int INDEX_KEY = AccumuloOperationsApiImpl.INDEX_KEY;

--- a/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiIfce.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiIfce.java
@@ -66,7 +66,6 @@ public interface AccumuloOperationsApiIfce {
     /**
 	 * Delete Accumulo row. Mark row as deleted.
 	 * @param conn conn
-	 * @param scanner scanner
 	 * @param tableName tableName
 	 * @param rowID rowID
 	 * @param colFam colFam
@@ -76,7 +75,7 @@ public interface AccumuloOperationsApiIfce {
 	 * @throws MutationsRejectedException change rejected
 	 * @throws TableNotFoundException table not found
 	 */
-   public Map<String, Value> deleteAccumuloRow(Connector conn, Scanner scanner, String tableName, Text rowID, Text colFam, Text colQual, Text visibility) throws MutationsRejectedException, TableNotFoundException;
+   public Map<String, Value> deleteAccumuloRow(Connector conn, String tableName, Text rowID, Text colFam, Text colQual, Text visibility) throws MutationsRejectedException, TableNotFoundException, AccumuloException, AccumuloSecurityException;
 
    /**
 	 * Enumerate Accumulo row that with the specific rowID and visibility.

--- a/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
@@ -32,6 +32,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -44,6 +45,13 @@ import org.renci.comet.CometOps;
 public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
     public static final String ERROR = "error";
     public static final String SUCCESS = "Success";
+
+    public static final int INDEX_ROW = 0;
+    public static final int INDEX_FAMILY = 1;
+    public static final int INDEX_KEY = 2;
+    public static final int INDEX_TIMESTAMP = 3;
+    public static final int INDEX_MAX = 4;
+    
     private static final Logger log = Logger.getLogger(AccumuloOperationsApiImpl.class);
     private static String user;
     private int retryDuration;
@@ -192,7 +200,6 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
     /**
      * Create new Accumulo table.
      * @param conn conn
-     * @param scanner scanner
      * @param tableName tableName
      * @param rowID rowID
      * @param colFam colFam
@@ -202,20 +209,51 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
      * @throws TableNotFoundException table not found
      * @throws MutationsRejectedException change rejected
      */
-    public Map<String, Value> deleteAccumuloRow(Connector conn, Scanner scanner, String tableName, Text rowID, Text colFam, Text colQual, Text visibility) throws TableNotFoundException, MutationsRejectedException {
+    public Map<String, Value> deleteAccumuloRow(Connector conn, String tableName, Text rowID, Text colFam, Text colQual, Text visibility) throws TableNotFoundException, MutationsRejectedException, AccumuloException, AccumuloSecurityException {
         Map<String, Value> output = new HashMap<>();
-        Authorizations auths = new Authorizations(visibility.toString());
-        BatchDeleter deleter= conn.createBatchDeleter(tableName, auths, 1, new BatchWriterConfig());
-        Collection<Range> ranges = new ArrayList<Range>();
-        Scanner tableScannerRange= conn.createScanner(tableName, auths);
-        tableScannerRange.setRange(Range.exact(rowID));
-        for (Entry<Key, Value> entry : tableScannerRange) {
-            ranges.add(new Range(entry.getKey().getRow()));
-            output.put(entry.getKey().toString(), entry.getValue());
+        BatchDeleter deleter = null;
+        int count = 0;
+        boolean succeed = false;
+        long beginTime = System.currentTimeMillis();
+        while(!succeed) {
+            try {
+                Authorizations auths = new Authorizations(visibility.toString());
+                conn.securityOperations().changeUserAuthorizations(user, auths);
+                deleter = conn.createBatchDeleter(tableName, auths, 1, new BatchWriterConfig());
+                /*
+                Collection<Range> ranges = new ArrayList<Range>();
+                tableScannerRange= conn.createScanner(tableName, auths);
+                tableScannerRange.setRange(Range.exact(rowID));
+                for (Entry<Key, Value> entry : tableScannerRange) {
+                    ranges.add(new Range(entry.getKey().getRow()));
+                    output.put(entry.getKey().toString(), entry.getValue());
+                }
+                */
+                deleter.setRanges(Arrays.asList(Range.exact(rowID, colFam, colQual)));
+                deleter.delete();
+                succeed = true;
+            }
+            catch (Exception e) {
+                log.error("Exception catched: " + e.toString());
+                if (e.getMessage() != null && (e.getMessage().contains("BAD_AUTHORIZATIONS"))) {
+                    if (visibility.equals(conn.securityOperations().getUserAuthorizations(user).toString())
+                       && (System.currentTimeMillis() <= (beginTime + retryDuration)))
+                    {
+                        //zookeepers might not fully propagate yet, give it a retry
+                        count++;
+                        log.error("retry(" + count + "): " + visibility + "/" + rowID.toString());
+                        continue;
+                    }
+                    log.error("authorizaions request: " + visibility + "/" + rowID.toString());
+                    log.error("authorizaions actual: " + conn.securityOperations().getUserAuthorizations(user).toString());
+                }
+                throw e;
+            } finally {
+                if(deleter != null) {
+                    deleter.close();
+                }
+            }
         }
-        deleter.setRanges(ranges);
-        deleter.delete();
-        deleter.close();
         return output;
     }
 
@@ -240,11 +278,12 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
                 scanner.setRange(new Range(rowID));
 
                 for (Map.Entry<Key, Value> entry : scanner) {
-                    //String[] key format: {Row, ColFam, ColQual}
-                    String[] keys = new String[3];
-                    keys[0] = entry.getKey().getRow().toString();
-                    keys[1] = entry.getKey().getColumnFamily().toString();
-                    keys[2] = entry.getKey().getColumnQualifier().toString();
+                    //String[] key format: {Row, ColFam, ColQual, Accumulo Timestamp}
+                    String[] keys = new String[INDEX_MAX];
+                    keys[INDEX_ROW] = entry.getKey().getRow().toString();
+                    keys[INDEX_FAMILY] = entry.getKey().getColumnFamily().toString();
+                    keys[INDEX_KEY] = entry.getKey().getColumnQualifier().toString();
+                    keys[INDEX_TIMESTAMP] = Long.toString(entry.getKey().getTimestamp());
                     Value value = entry.getValue();
                     output.put(keys, value);
                 }
@@ -314,12 +353,11 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
                 scanner.setRange(new Range(rowID));
                 scanner.fetchColumn(colFam, colQual);
                 for (Map.Entry<Key, Value> entry : scanner) {
-                    String[] keys = new String[5];
-                    keys[0] = entry.getKey().getRow().toString();
-                    keys[1] = entry.getKey().getColumnFamily().toString();
-                    keys[2] = entry.getKey().getColumnQualifier().toString();
-                    keys[3] = Long.toString(entry.getKey().getTimestamp());
-                    keys[4] = Boolean.toString(entry.getKey().isDeleted());
+                    String[] keys = new String[INDEX_MAX];
+                    keys[INDEX_ROW] = entry.getKey().getRow().toString();
+                    keys[INDEX_FAMILY] = entry.getKey().getColumnFamily().toString();
+                    keys[INDEX_KEY] = entry.getKey().getColumnQualifier().toString();
+                    keys[INDEX_TIMESTAMP] = Long.toString(entry.getKey().getTimestamp());
                     Value value = entry.getValue();
                     output.put(keys, value);
                 }

--- a/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
+++ b/comet-accumulo/src/main/java/org/renci/comet/accumuloops/AccumuloOperationsApiImpl.java
@@ -220,15 +220,6 @@ public class AccumuloOperationsApiImpl implements AccumuloOperationsApiIfce {
                 Authorizations auths = new Authorizations(visibility.toString());
                 conn.securityOperations().changeUserAuthorizations(user, auths);
                 deleter = conn.createBatchDeleter(tableName, auths, 1, new BatchWriterConfig());
-                /*
-                Collection<Range> ranges = new ArrayList<Range>();
-                tableScannerRange= conn.createScanner(tableName, auths);
-                tableScannerRange.setRange(Range.exact(rowID));
-                for (Entry<Key, Value> entry : tableScannerRange) {
-                    ranges.add(new Range(entry.getKey().getRow()));
-                    output.put(entry.getKey().toString(), entry.getValue());
-                }
-                */
                 deleter.setRanges(Arrays.asList(Range.exact(rowID, colFam, colQual)));
                 deleter.delete();
                 succeed = true;

--- a/test/docker-compose-test.yml
+++ b/test/docker-compose-test.yml
@@ -1,0 +1,37 @@
+version: '3.1'
+
+services:
+
+  comet:
+    image: rencinrig/comet-spring:1.0.5-SNAPSHOT
+    container_name: comet-test
+    volumes:
+      - /tmp/cometlog:/var/log/
+    restart: always
+    hostname: comet-test
+    ports:
+      - 8222:8111                            # use port 8222
+    extra_hosts:
+      - "zoo1:192.168.100.34"
+      - "zoo2:192.168.100.35"
+      - "zoo3:192.168.100.31"
+      - "comet-w1:192.168.100.32"
+      - "comet-w2:192.168.100.33"
+    environment:
+      ACCUMULO_TABLENAME: testtable          # use test table
+      ACCUMULO_ZOOSERVERS: zoo1,zoo2,zoo3
+      ACCUMULO_INSTANCE: exogeni-accumulo
+      ACCUMULO_USER: testuser                # use test user
+      ACCUMULO_PASSWORD: nrig
+      COMET_CHECK_TOKEN_STRENGTH: 'false'
+      COMET_CHECK_CLIENT_CERT: 'false'
+      COMET_SSL_KEY_STORE: cometserver.jks
+      COMET_SSL_KEY_STORE_PWD: 'changeme'
+      COMET_SSL_KEY_PWD: 'changeme'
+      COMET_SSL_TRUST_STORE: comettrustedstore.jks
+      COMET_SSL_TRUST_STORE_PWD: 'changeme'
+      COMET_RETRY_DURATION: '1000'
+      COMET_RECORD_EXPIRE_TIME: '6000'            # 6 seconds
+    logging:
+      driver: "none"
+

--- a/test/test_comet.py
+++ b/test/test_comet.py
@@ -1,0 +1,192 @@
+import time
+import requests
+
+COMET_SITE = 'https://comet-hn2.exogeni.net:8222/'
+EXPIRE_TIME = 6         # COMET_RECORD_EXPIRE_TIME: '6000' in docker-compose-test.yml
+TTL = EXPIRE_TIME * 2  
+
+headers = {'Accept': 'application/json'}
+
+RECORD_1 = {
+    'contextID' : 'RECORD_0_CONTEXTID',
+    'family'    : 'RECORD_0_FAMILY',
+    'readToken' : 'RECORD_0_READTOKEN',
+    'Key'       : 'RECORD_0_KEY',
+    'writeToken': 'RECORD_0_WRITETOKEN',
+    'value'     : 'RECORD_0_VALUE'
+}
+
+
+def test_write_scope_api():
+    record = RECORD_1
+    params = {
+        'contextID': record['contextID'],
+        'family': record['family'],
+        'Key': record['Key'],
+        'readToken': record['readToken'],
+        'writeToken': record['writeToken']
+    }
+    response = requests.post((COMET_SITE + '/writeScope'), headers=headers, params=params,
+                             data=record['value'], cert='', verify='')
+    assert response.status_code == 200
+
+
+def test_read_scope_api():
+    record = RECORD_1
+    params = {
+        'contextID': record['contextID'],
+        'family': record['family'],
+        'Key': record['Key'],
+        'readToken': record['readToken'],
+    }
+    response = requests.get((COMET_SITE + '/readScope'), headers=headers, params=params,
+                            cert='', verify='')
+    json_value = (response.json()['value'])
+    assert response.status_code == 200
+    assert json_value['contextId'] == record['contextID']
+    assert json_value['family'] == record['family']
+    assert json_value['key'] == record['Key']
+    assert json_value['value'] == record['value']
+
+
+def test_enumerate_scope_api_with_family():
+    record = RECORD_1
+    params = {
+        'contextID': record['contextID'],
+        'family': record['family'],
+        'readToken': record['readToken'],
+    }
+    response = requests.get((COMET_SITE + '/enumerateScope'), headers=headers, params=params,
+                            cert='', verify='')
+    assert response.status_code == 200
+    json_value = (response.json()['value'])
+    assert json_value['contextId'] == record['contextID']
+    assert json_value['family'] == record['family']
+    found_record = False
+    entries = json_value['entries']
+    for entry in entries:
+        if entry['key'] == record['Key'] and entry['value'] == record['value']:
+            found_record = True
+    assert found_record is True
+
+
+def test_enumerate_scope_api():
+    record = RECORD_1
+    params = {
+        'contextID': record['contextID'],
+        'readToken': record['readToken'],
+    }
+    response = requests.get((COMET_SITE + '/enumerateScope'), headers=headers, params=params,
+                            cert='', verify='')
+    assert response.status_code == 200
+    json_value = (response.json()['value'])
+    assert json_value['contextId'] == record['contextID']
+    print(json_value)
+    found_record = False
+    entries = json_value['entries']
+    for entry in entries:
+        if entry['family'] == record['family'] and entry['key'] == record['Key'] and entry['value'] == record['value']:
+            found_record = True
+    assert found_record is True
+
+
+def test_delete_scope_api():
+    record = RECORD_1
+    params = {
+        'contextID': record['contextID'],
+        'family': record['family'],
+        'Key': record['Key'],
+        'readToken': record['readToken'],
+        'writeToken': record['writeToken']
+    }
+    response = requests.delete((COMET_SITE + '/deleteScope'), headers=headers, params=params,
+                               cert='', verify='')
+    assert response.status_code == 200
+
+    # then read back, make sure empty
+    params = {
+        'contextID': record['contextID'],
+        'family': record['family'],
+        'Key': record['Key'],
+        'readToken': record['readToken']
+    }
+    response = requests.get((COMET_SITE + '/readScope'), headers=headers, params=params,
+                            cert='', verify='')
+    assert response.status_code == 200
+    json_value = (response.json()['value'])
+    assert len(json_value) == 0
+
+
+def test_record_deleted_after_ttl():
+    test_write_scope_api()
+    time.sleep(TTL)
+
+    record = RECORD_1
+    # then read, make sure empty
+    params = {
+        'contextID': record['contextID'],
+        'family': record['family'],
+        'Key': record['Key'],
+        'readToken': record['readToken'],
+    }
+    response = requests.get((COMET_SITE + '/readScope'), headers=headers, params=params,
+                            cert='', verify='')
+    assert response.status_code == 200
+    json_value = (response.json()['value'])
+    assert len(json_value) == 0
+
+
+def test_record_not_deleted_if_read_accessed():
+    test_write_scope_api()
+    time.sleep(1)
+    test_read_scope_api()
+    time.sleep(EXPIRE_TIME)
+    test_read_scope_api()
+    time.sleep(TTL-EXPIRE_TIME-1)
+    test_read_scope_api()
+
+
+def test_record_keeps_alive_if_read_accessed():
+    test_write_scope_api()
+    for _ in range(6):
+        time.sleep(EXPIRE_TIME)
+        test_read_scope_api()
+
+
+def test_record_not_deleted_if_enumlate_accessed():
+    test_write_scope_api()
+    time.sleep(1)
+    test_enumerate_scope_api()
+    time.sleep(EXPIRE_TIME)
+    test_enumerate_scope_api()
+    time.sleep(TTL-EXPIRE_TIME-1)
+    test_enumerate_scope_api()
+
+
+def test_record_keeps_alive_if_enumlate_accessed():
+    test_write_scope_api()
+    for _ in range(6):
+        time.sleep(EXPIRE_TIME)
+        test_enumerate_scope_api()
+
+
+def test_record_alive_then_deleted():
+    test_write_scope_api()
+    for _ in range(3):
+        time.sleep(EXPIRE_TIME)
+        test_read_scope_api()
+    time.sleep(TTL)
+    record = RECORD_1
+    # then read, make sure empty
+    params = {
+        'contextID': record['contextID'],
+        'family': record['family'],
+        'Key': record['Key'],
+        'readToken': record['readToken'],
+    }
+    response = requests.get((COMET_SITE + '/readScope'), headers=headers, params=params,
+                            cert='', verify='')
+    assert response.status_code == 200
+    json_value = (response.json()['value'])
+    assert len(json_value) == 0
+

--- a/vmware-cluster/create-accu-user.sh
+++ b/vmware-cluster/create-accu-user.sh
@@ -7,4 +7,5 @@ runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass}
 read -p 'Enter the table name for the user to READ/WRITE: ' table
 runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"grant Table.READ -t ${table} -u ${username}\""
 runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"grant Table.WRITE -t ${table} -u ${username}\""
+runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"grant Table.ALTER_TABLE -t ${table} -u ${username}\""
 runuser -l hadoop -c "${ACCUMULO_HOME}/bin/accumulo shell -u root -p ${rootpass} -e \"grant -s System.ALTER_USER -u ${username}\""

--- a/vmware-cluster/docker-compose.yml
+++ b/vmware-cluster/docker-compose.yml
@@ -31,5 +31,6 @@ services:
       COMET_SSL_TRUST_STORE: comettrustedstore.jks
       COMET_SSL_TRUST_STORE_PWD: 'changeme'
       COMET_RETRY_DURATION: '1000'
+      COMET_RECORD_EXPIRE_TIME: '15552000000' # 180 days in milliseconds
     logging:
       driver: "none"

--- a/vmware-cluster/setupzookeeper.sh
+++ b/vmware-cluster/setupzookeeper.sh
@@ -10,7 +10,7 @@ if [ $# -ne 1 ]; then
 fi
 
 JAVA_VERSION=`java -version 2>&1 | awk -F '\"' '/version/ {print $2}'| cut -d'_' -f1`
-if ["$JAVA_VERSION" !="1.8.0" ]; then
+if [ "$JAVA_VERSION" != "1.8.0" ]; then
     echo "Removing $JAVA_VERSION"
     java_rpm_to_be_removed=`rpm -qa | grep openjdk-$JAVA_VERSION`
     rpm -e \"$java_rpm_to_be_removed


### PR DESCRIPTION
To avoid data nodes out of disk space eventually, Comet will delete data if requested by user and also let data ageoff if there is no access activity.

Changes in this pull request:

1. When user requests DeleteScope, instead of fake deletion (only mark ifDeleted and update in the Accumulo), now Comet will perform actual deletion to the Accumulo. 

2. Turn on Accumulo AgeOffFilter, and perform internal write to update timestamp if the data is too old during read or enumerate operation. A new environment variable "COMET_RECORD_EXPIRE_TIME" is introduced, records are expected to access (i.e. Read/Enumerate/Write) at least once in this period of time in order to keep records alive.

3. COMET still keeps the original user write timestamp in case this information is needed in future.
   Previous format in Accumulo record value: 
**{ifDeleted, writeToken, scopeValue, Comet_version, deletionTimeStamp }**
   Now New format in Accumulo record value : 
**{ifDeleted, writeToken, scopeValue, Comet_version, deletionTimeStamp, userWriteTimeStamp }**
   Note: Althouth **ifDeleted** and **deletionTimeStamp** are not used anymore, keep it to be backward compatible with previous versions.

4. test folder
    docker-compose-test.yml: to setup an test instance on comet-hn2 using port 8222
    test_comet.py          : testcases can run by pytest